### PR TITLE
[add] TaskCall::update<>()

### DIFF
--- a/TaskSystem/aiUtil/task/TaskSystem.hpp
+++ b/TaskSystem/aiUtil/task/TaskSystem.hpp
@@ -4,7 +4,7 @@
 #include <map>
 #include <memory>
 #include <cassert>
-#include <regex>
+#include <type_traits>
 #include <Siv3D/String.hpp>
 
 namespace aiUtil::task {
@@ -120,6 +120,20 @@ public:
 				if (task.second->updateCondition()) {
 					task.second->update();
 				}
+			}
+		}
+
+		/// <summary>
+		/// 特定の型にキャストできるタスクのupdate()を呼び出す
+		/// </summary>
+		template<class SpecificTask,
+				 std::enable_if_t<std::is_base_of_v<Task, SpecificTask>>* = nullptr>
+		static inline void update()
+		{
+			for (auto& task : getInstance().taskList_) {
+				if (auto derived = std::dynamic_pointer_cast<SpecificTask>(task.second);
+					derived && derived->updateCondition())
+					derived->update();
 			}
 		}
 	private:


### PR DESCRIPTION
`SpecificTask`にダイナミックキャストできるようなタスクのみをupdateする`TaskCall::update<T>()`を作りました。
例えば、`class OnChangeCondTask`といった、何らかの条件が変更された時だけ`update`を呼び出してほしいタスククラスを用意して、条件更新時に`TaskSystem::TaskCall::update<OnChangeCondTask>()`と書けば`OnChangeCondTask`を継承したタスクだけが実行されます。

また、このメソッドはプログラムのメインループ内でタスクの順番を種類ごとに明確にすることができます。ゲームの場合、描画対象の座標や状態の更新を経てから描画をしたいはずです。
従来ですと、タスクはハッシュテーブルに格納されていますから、どのタスクの後にどのタスクが実行されるか分かりません。しかし、このメソッドを追加したことによってタスクに優先度をつけることが可能となりました。具体的には以下のようなタスククラスを作成し優先度に応じて継承することで簡単に優先度の概念を導入できます。

```cpp
template<int Priority>
class TaskPriority : public Task {};
```

優先度ごとに実行するには以下のようにします。

```cpp
TaskSystem::TaskCall::update<TaskPriority<0>>();
TaskSystem::TaskCall::update<TaskPriority<1>>();
// ...
```
